### PR TITLE
Basic Pop'n Music Kaimei support

### DIFF
--- a/core_common.py
+++ b/core_common.py
@@ -105,6 +105,11 @@ async def core_get_game_version_from_software_version(software_version):
     elif model == "KFC":
         if ext >= 2020090402:  # ???
             return 6
+    
+    elif model == "M39":
+        if ext >= 2022061300:  # ???
+            print("OK!")
+            return 31
 
     else:
         return 0

--- a/core_common.py
+++ b/core_common.py
@@ -108,7 +108,6 @@ async def core_get_game_version_from_software_version(software_version):
     
     elif model == "M39":
         if ext >= 2022061300:  # ???
-            print("OK!")
             return 31
 
     else:

--- a/modules/core/cardmng.py
+++ b/modules/core/cardmng.py
@@ -16,6 +16,7 @@ def get_target_table(game_id):
         "PAN": "nostalgia_profile",
         "JDZ": "iidx_profile",
         "KDZ": "iidx_profile",
+        "M39": "popn_profile",
     }
 
     return target_table[game_id]

--- a/pyeamu.py
+++ b/pyeamu.py
@@ -16,6 +16,15 @@ import utils.card as conv
 
 from core_common import core_process_request, core_prepare_response, E
 
+from modules.core.pcbtracker import pcbtracker_alive
+from modules.core.message import message_get
+from modules.core.facility import facility_get
+from modules.core.package import package_list
+from modules.core.pcbevent import pcbevent_put
+from modules.core.cardmng import cardmng_inquire
+from modules.core.cardmng import cardmng_authpass
+from modules.core.cardmng import cardmng_bindmodel
+from modules.core.cardmng import cardmng_getrefid
 
 def urlpathjoin(parts, sep="/"):
     return sep + sep.join([x.lstrip(sep) for x in parts])
@@ -90,6 +99,34 @@ if __name__ == "__main__":
     print("https://github.com/drmext/MonkeyBusiness")
     print()
     uvicorn.run("pyeamu:app", host=config.ip, port=config.port, reload=True)
+
+
+@app.post(urlpathjoin([config.services_prefix]))
+async def services_get_pop(model: Request, module: str, method: str):
+
+    if module == "pcbtracker":
+        return await pcbtracker_alive(model)
+    elif module == "message":
+        return await message_get(model)
+    elif module == "facility":
+        return await facility_get(model)
+    elif module == "package":
+        return await package_list(model)
+    elif module == "pcbevent":
+        return await pcbevent_put(model)
+    elif module == "cardmng":
+        if method == "inquire":
+            return await cardmng_inquire(model)
+        elif method == "getrefid":
+            return await cardmng_getrefid(model)
+        elif method == "bindmodel":
+            return await cardmng_bindmodel(model)
+        elif method == "authpass":
+            return await cardmng_authpass(model)
+    elif module == "services":
+        services_get(model)
+    else:
+        return
 
 
 @app.post(urlpathjoin([config.services_prefix, "/{gameinfo}/services/get"]))
@@ -180,3 +217,19 @@ async def card_conv(card: str):
         uid = conv.to_uid(card)
         kid = card
     return {"uid": uid, "konami_id": kid}
+
+# TODO: Answer /local2 calls, create responses and apropriate functions to go with them
+#@app.post("/local2")
+#async def local_two(model: Request, module: str):
+#    
+#    #if module == "pcb24":
+     # Straight up broken. I was unable to translate the incoming XML,
+     # seems like part of it is missing or jumbled. It also however seems
+     # like you dont really need it? That is the conclusion for now.
+     # (And I know its compressed, still nothing useful) 
+
+#    # To be implemented
+#    if module == "player24":
+#        request_info = await core_process_request(model)
+#        return
+#    


### PR DESCRIPTION
Hello,
I wanted to help this project a little bit so I can fully migrate from other servers.

I have added the most basic support for Pop'n Music Kaimei riddles. The game successfully  gets past network check however you are still unable to log in, register and save scores.

Unlike DDR for example this game and (Gitadora Exchain too for that matter) communicate not through individual absolute URLs but using /something?something_else=.... Functions for the endpoints were sufficient, however you really have to point to just the function.

I am not sure what exactly the return values in core_common mean but I just made it one bigger then what is present.

I haven't yet made much progress beyond that other then /local2?module=pcb24 which from my observations so far is a) broken and b) not necessary to address for further progress.

Hopefully by the end of the week I will have more positive news and if lucky, have the game fully working.

Further unrelated work will be for Dance Evolution as that is one game my friend is playing and would like a functioning server. Also unless you are working on it/have it planned I will make .sh equivalent of the starting script. 